### PR TITLE
fix: patch fast-xml-parser vulnerable version (Dependabot #4)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,5 +8,5 @@ module.exports = function (word, opt) {
 
   return api
     .fetchTerm(word, opt)
-    .then(xml => new XMLParser().parse(xml))
+    .then(xml => new XMLParser({ processEntities: false }).parse(xml))
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^2.0.0",
-    "fast-xml-parser": "^4.2.4",
+    "fast-xml-parser": "^5.3.6",
     "meow": "^3.7.0",
     "node-fetch": "^2.6.1",
     "ora": "^1.3.0",


### PR DESCRIPTION
## What
- bump `fast-xml-parser` from `^4.2.4` to `^5.3.6` (patched for CVE-2026-26278 / GHSA-jmr7-xgp7-cmfj)
- disable XML entity expansion at runtime via `new XMLParser({ processEntities: false })`

## Why
Dependabot alert #4 flags DoS risk through entity expansion in affected fast-xml-parser versions.

## Validation
- ran `npm test` successfully (standard + ava, 4 passed)
